### PR TITLE
Select proper reference in page header when using 'nochapter' mode

### DIFF
--- a/njubachelor.dtx
+++ b/njubachelor.dtx
@@ -322,10 +322,18 @@
   \fancyfoot[C]{\thepage}
   \ifNJU@oneside
     \fancyhead[L]{\fangsong \NJU@subject}
-    \fancyhead[R]{\fangsong \leftmark}
+    \ifNJU@chapter
+        \fancyhead[R]{\fangsong \leftmark}
+    \else
+        \fancyhead[R]{\fangsong \rightmark}
+    \fi
   \else
     \fancyhead[EC]{\fangsong \NJU@subject}
-    \fancyhead[OC]{\fangsong \leftmark}
+    \ifNJU@chapter
+        \fancyhead[R]{\fangsong \leftmark}
+    \else
+        \fancyhead[R]{\fangsong \rightmark}
+    \fi
   \fi
 \else \pagestyle{plain}
 \fi

--- a/njubachelor.dtx
+++ b/njubachelor.dtx
@@ -330,9 +330,9 @@
   \else
     \fancyhead[EC]{\fangsong \NJU@subject}
     \ifNJU@chapter
-        \fancyhead[R]{\fangsong \leftmark}
+        \fancyhead[OC]{\fangsong \leftmark}
     \else
-        \fancyhead[R]{\fangsong \rightmark}
+        \fancyhead[OC]{\fangsong \rightmark}
     \fi
   \fi
 \else \pagestyle{plain}


### PR DESCRIPTION
When using "nochapter" mode, page header should choose the **section** title as supplementary text, rather than the **chapter** title.